### PR TITLE
Pass in the IBM driver from the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Simply add this code at the end of your ``app/config/database.php`` file:
     'ibmi' => [
         'driver'               => 'odbc' / 'ibm',
          // General settings
+        'ibmDriver'            => 'iSeries Access ODBC Driver',
         'host'                 => 'server',
         'username'             => '',
         'password'             => '',

--- a/src/Connectors/ODBCConnector.php
+++ b/src/Connectors/ODBCConnector.php
@@ -30,7 +30,7 @@ class ODBCConnector extends Connector implements ConnectorInterface
 
         $dsn = "odbc:"
              // General settings
-             . "DRIVER={iSeries Access ODBC Driver};"
+             . "DRIVER={$ibmDriver};"
              . "SYSTEM=$host;"
              . "UserID=$username;"
              . "Password=$password;"

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -64,6 +64,7 @@ return [
         'ibmi' => [
             'driver'               => 'odbc' / 'ibm',
              // General settings
+            'ibmDriver'            => 'iSeries Access ODBC Driver',
             'host'                 => 'server',
             'username'             => '',
             'password'             => '',


### PR DESCRIPTION
I have the need to change the driver hard-coded in **ODBCConnector.php** as `iSeries Access ODBC Driver` to the name of my driver which is `IBM i Access ODBC Driver`.

Wouldn't it be better to allow this setting to be configured in the **config/database.php** or **config/packages/cooperl/laravel-db2/config.php** files?