### PR TITLE
[Bug] compileSelect forgets a 'select' statement when using 'union'

### DIFF
--- a/src/Query/Grammars/DB2Grammar.php
+++ b/src/Query/Grammars/DB2Grammar.php
@@ -40,6 +40,8 @@ class DB2Grammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
+        if (is_null($query->columns)) $query->columns = array('*');
+        
         $components = $this->compileComponents($query);
 
         // If an offset is present on the query, we will need to wrap the query in


### PR DESCRIPTION
Some unions don't get the select clause they need if you don't manually ->select('*')

Perhaps this problem is only present in my particular use-case, but this seems to be a duplicate of the bug reported and fixed here: https://github.com/laravel/framework/issues/1223 

The proposed change is just a copy of the change made in /Illuminate/Database/Query/Grammars/Grammar.php in response to that bug report.

This fixed my problem, hopefully it is acceptable.