### PR TITLE
Qualify * with table name when row_number() follows

### DIFF
--- a/src/Query/Grammars/DB2Grammar.php
+++ b/src/Query/Grammars/DB2Grammar.php
@@ -79,6 +79,12 @@ class DB2Grammar extends Grammar
 
         $columns = (!empty($components['columns']) ? $components['columns'] . ', ': 'select');
 
+        // DB2 doesn't allow unqualified * followed by more columns, 
+        // see https://github.com/cooperl22/laravel-db2/issues/7
+        if($columns == 'select *, ' && $query->from){ 
+            $columns = 'select '.$this->tablePrefix.$query->from.'.*, ';
+        }
+
         $components['columns'] = $this->compileOver($orderings, $columns);
 
         unset($components['orders']);


### PR DESCRIPTION
SQL0104 - Token , was not valid when using Laravel 5.1 ::paginate(xx) occurs when using paginate without a select.

A statement like: `select * from (select *, row_number() over (order by 1) as row_num from PORHDR) as temp_table where row_num between 121 and 160` is created, and an error is thrown because `select *, row_number()` is not allowed. The pull request qualifies the table name in this kind of query so we get a query like: `select * from (select PORHDR.*, row_number() over (order by 1) as row_num from PORHDR) as temp_table where row_num between 121 and 160`, which works.

Fixes https://github.com/cooperl22/laravel-db2/issues/7 and https://github.com/cooperl22/laravel-ibmi/issues/3, I think.

I haven't gotten into chunking results yet, but this might also address the problem https://github.com/cooperl22/laravel-db2/pull/4 is trying to fix. However, from a quick look, that pull request breaks my code because it does not return the expected columns.