### PR TITLE
[Fix] Fix number of parameters

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -37,10 +37,11 @@ class Blueprint extends \Illuminate\Database\Schema\Blueprint
      * @param  string $type
      * @param  string|array $columns
      * @param  string $index
+     * @param  string|null $algorithm
      *
      * @return \Illuminate\Support\Fluent
      */
-    protected function indexCommand($type, $columns, $index)
+    protected function indexCommand($type, $columns, $index, $algorithm = null)
     {
         $columns = (array) $columns;
 


### PR DESCRIPTION
Fix for this error:
[ErrorException]
  Declaration of Cooperl\Database\DB2\Schema\Blueprint::indexCommand() should be compatible with Illuminate\Databa
  se\Schema\Blueprint::indexCommand($type, $columns, $index, $algorithm = NULL)