### PR TITLE
Add 'name' to config array

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Simply add this code at the end of your ``app/config/database.php`` file:
     */
 
     'ibmi' => [
+        'name' => 'ibmi',
         'driver' => 'db2_ibmi_odbc',
         // or 'db2_ibmi_ibm' / 'db2_zos_odbc' / 'db2_expressc_odbc
         'driverName' => '{IBM i Access ODBC Driver}',


### PR DESCRIPTION
After updating to ~5.4, I got a new bug as a result of the 'name' attribute not being defined in my config array. My primary database connection is to a MySQL database on localhost, while my IBM i connection is on another host. When the name attribute is empty, and Laravel's Builder did a findOrNew() that resulted in a 'new', it made a new instance and set the connection name to the results of `$this->query->getConnection()->getName()` which was returning null because there was no 'name' attribute in the config array. This caused the new instance to use my default connection, which did not work.

YMMV - I am still on Laravel 5.2, perhaps this has improved in newer versions, but it was a bit of a bear to track down since it only fails when findOrNew needs to create rather than find. 

This pull request simply adds back the 'name' attribute in the readme. It looks like it was used in place of driverName at one point? It was removed in commit https://github.com/cooperl22/laravel-db2/commit/e8f17c13a7839717a9bc029ab57d7f6598b52b97. If you have more information about the undocumented standard laravel setting method in that commit, I would be interested to see it to make sure I'm diagnosing this correctly.
