### PR TITLE
Updating method getdsn get connection parameters

### DIFF
--- a/src/Connectors/ODBCZOSConnector.php
+++ b/src/Connectors/ODBCZOSConnector.php
@@ -17,7 +17,7 @@ class ODBCZOSConnector extends ODBCConnector
     protected function getDsn(array $config)
     {
         $dsnParts = [
-            "odbc:DRIVER=$driverName",
+            'odbc:DRIVER=%s',
             'Database=%s',
             'Hostname=%s',
             'Port=%s',
@@ -28,6 +28,7 @@ class ODBCZOSConnector extends ODBCConnector
         ];
 
         $dsnConfig = [
+            $config['driverName'],
             $config['database'],
             $config['host'],
             $config['port'],


### PR DESCRIPTION
Updating getDsn get parameters, when using `db2_zos_odbc` connection, for current version `dev-master`.