### PR TITLE
Added a check to prevent the 'Set schema' query if a schema is not provided

### DIFF
--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -36,11 +36,7 @@ class DB2Connection extends Connection
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
         
-        if(isset($config['schema']) && $config['schema'])
-        {
-            $this->currentSchema = $this->defaultSchema = strtoupper($config['schema']);
-        }
-        
+        $this->currentSchema = $this->defaultSchema = strtoupper($config['schema'] ?? null);
     }
 
     /**

--- a/src/DB2Connection.php
+++ b/src/DB2Connection.php
@@ -35,7 +35,12 @@ class DB2Connection extends Connection
     public function __construct(PDO $pdo, $database = '', $tablePrefix = '', array $config = [])
     {
         parent::__construct($pdo, $database, $tablePrefix, $config);
-        $this->currentSchema = $this->defaultSchema = strtoupper($config['schema']);
+        
+        if(isset($config['schema']) && $config['schema'])
+        {
+            $this->currentSchema = $this->defaultSchema = strtoupper($config['schema']);
+        }
+        
     }
 
     /**


### PR DESCRIPTION
To avoid notice "Undefined index: schema" or error "SQLSTATE[42000]: Syntax error or access violation: 0 [IBM][System i Access ODBC Driver][DB2 for i5/OS]SQL0104 - Token <FINE-ISTRUZIONI> non valido. Token validi" if schema is left empty.