### PR TITLE
Add offset_compatibility_mode option for newer versions of DB2

### DIFF
--- a/src/Database/DB2Connection.php
+++ b/src/Database/DB2Connection.php
@@ -108,6 +108,10 @@ class DB2Connection extends Connection
             $defaultGrammar->setDateFormat($this->config['date_format']);
         }
 
+        if (array_key_exists('offset_compatibility_mode', $this->config)) {
+            $defaultGrammar->setOffsetCompatibilityMode($this->config['offset_compatibility_mode']);
+        }
+
         return $this->withTablePrefix($defaultGrammar);
     }
 

--- a/src/Database/Query/Grammars/DB2Grammar.php
+++ b/src/Database/Query/Grammars/DB2Grammar.php
@@ -20,6 +20,12 @@ class DB2Grammar extends Grammar
     protected $dateFormat;
 
     /**
+     * Offset compatibility mode true triggers FETCH FIRST X ROWS and ROW_NUM behavior for older versions of DB2
+     * @var bool
+     */
+    protected $offsetCompatibilityMode = true;
+
+    /**
      * Wrap a single string in keyword identifiers.
      *
      * @param string $value
@@ -45,7 +51,10 @@ class DB2Grammar extends Grammar
      */
     protected function compileLimit(Builder $query, $limit)
     {
-        return "FETCH FIRST $limit ROWS ONLY";
+        if($this->offsetCompatibilityMode){
+            return "FETCH FIRST $limit ROWS ONLY";
+        }
+        return parent::compileLimit($query, $limit);
     }
 
     /**
@@ -57,6 +66,10 @@ class DB2Grammar extends Grammar
      */
     public function compileSelect(Builder $query)
     {
+        if(!$this->offsetCompatibilityMode){
+            return parent::compileSelect($query);
+        }
+
         if (is_null($query->columns)) {
             $query->columns = ['*'];
         }
@@ -183,7 +196,10 @@ class DB2Grammar extends Grammar
      */
     protected function compileOffset(Builder $query, $offset)
     {
-        return '';
+        if($this->offsetCompatibilityMode){
+            return '';
+        }
+        return parent::compileOffset($query, $offset);
     }
 
     /**
@@ -219,6 +235,16 @@ class DB2Grammar extends Grammar
     public function setDateFormat($dateFormat)
     {
         $this->dateFormat = $dateFormat;
+    }
+
+    /**
+     * Set offset compatibility mode to trigger FETCH FIRST X ROWS and ROW_NUM behavior for older versions of DB2
+     *
+     * @param $bool
+     */
+    public function setOffsetCompatibilityMode($bool)
+    {
+        $this->offsetCompatibilityMode = $bool;
     }
 
     /**


### PR DESCRIPTION
My attempts to fix https://github.com/cooperl22/laravel-db2/issues/71 with FETCH FIRST X ROWS and ROW_NUM were sloppy and created more problems than they solved. Then I found this: https://www.itjungle.com/2016/01/12/fhg011216-story03/ which got me to try using OFFSET and LIMIT against my DB2 instance. 

For any users of this repo who do not know, support for OFFSET and LIMIT was added to DB2 for i 7.1 and 7.2. You need the following DB PTF group levels to get this support:

- SF99702 level 9 for IBM i 7.2
- SF99701 level 38 for IBM i 7.1

https://stackoverflow.com/a/35212852

For those who can use OFFSET and LIMIT, this PR adds a new configuration option called offset_compatibility_mode which is true by default to maintain existing behavior but when set to false it will bypass the FETCH FIRST and ROW_NUM logic of this repo in favor of the parent methods (offset and limit). This clears up the issue with union support being lost in a framework update. 